### PR TITLE
feat: add sqs consumer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,7 @@
 node_modules
 npm-debug.log
+.env-tpl
+.env
+.gitignore
+ipfs-pinning-service.yaml
+README.md

--- a/.env.tpl
+++ b/.env.tpl
@@ -2,7 +2,8 @@
 GATEWAY_URL="https://ipfs.io"
 
 # Set and uncomment the below
-# S3_ACCESS_KEY_ID=
-# S3_SECRET_ACCESS_KEY_ID=
+# AWS_REGION="us-east-2"
+# AWS_SECRET_ACCESS_KEY=
+# AWS_ACCESS_KEY_ID=
 # S3_BUCKET_NAME=
-# S3_BUCKET_REGION="us-east-2"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN npm ci --only=production
 COPY . .
 
 EXPOSE 3000
-CMD [ "npm", "run", "start:prod" ]
+CMD [ "npm", "run", "start:consumer" ]

--- a/README.md
+++ b/README.md
@@ -96,21 +96,39 @@ ECS ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ 
 
 </pre>
 
+## Integration with Elastic Provider
+
+see: https://github.com/ipfs-elastic-provider/ipfs-elastic-provider
+
+### Option 1 - use uploads v2
+
+The initial /pins lambda asks web3.storage for a signed s3 upload url instead of picking the bucket to write to itself.
+- Means we write the CAR directly into Elastic Provider. But we need something to say "upload complete" so that we update the PinRequests DynamoDB table... This could be done by pickup once the upload is complete. We would at that point have the full CAR, so we could mark it as pinned at that point, but it won't be available until later, after the elastic provider has processed it.
+
+
+### Option 2 - inform Elastic provider on upload complete
+
+Send a message on the indexer SQS topic from our lambda when the CAR is written to our s3 bucket.
+
 ## References
 
 > When a consumer (component 2) is ready to process messages, it consumes messages from the queue, and message A is returned. While message A is being processed, it remains in the queue and isn't returned to subsequent receive requests for the duration of the visibility timeout.
 >
-> The consumer (component 2) deletes message A from the queue to prevent the message from being received and processed again when the visibility timeout expires.
-– https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-basic-architecture.html
+> The consumer (component 2) deletes message A from the queue to prevent the message from being received and processed again when the visibility timeout expires. 
+> 
+>https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-basic-architecture.html
 
 > If you don't know how long it takes to process a message, create a heartbeat for your consumer process: Specify the initial visibility timeout (for example, 2 minutes) and then—as long as your consumer still works on the message—keep extending the visibility timeout by 2 minutes every minute.
-– https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/working-with-messages.html
+>
+> https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/working-with-messages.html
 
-> Worker Services allow you to implement asynchronous service-to-service communication with pub/sub architectures. Your microservices in your application can publish events to Amazon SNS topics that can then be consumed by a "Worker Service". 
-– https://aws.github.io/copilot-cli/docs/concepts/services/#request-driven-web-service
+> Worker Services allow you to implement asynchronous service-to-service communication with pub/sub architectures. Your microservices in your application can publish events to Amazon SNS topics that can then be consumed by a "Worker Service".
+>
+> https://aws.github.io/copilot-cli/docs/concepts/services/#request-driven-web-service
 
 > A Backend Service on AWS Copilot a one-click deployment of a gateway as a "backend service" (autoscaling at Fargate Spot pricing, each node has a port open so is a full participant in libp2p, 200G ssd for the datastore, 4cores and up to 30G RAM, no LB though - dns based discovery for client-side load balancing).
-– https://github.com/ipfs-shipyard/go-ipfs-docker-examples/tree/main/gateway-copilot-backend-service
+>
+> https://github.com/ipfs-shipyard/go-ipfs-docker-examples/tree/main/gateway-copilot-backend-service
 
 
 [pinning service api]: https://ipfs.github.io/pinning-services-api-spec/

--- a/app.js
+++ b/app.js
@@ -4,15 +4,15 @@ import s3 from './plugins/s3.js'
 
 const envSchema = {
   type: 'object',
-  required: ['PORT', 'NODE_ENV', 'GATEWAY_URL', 'S3_BUCKET_NAME', 'S3_BUCKET_REGION', 'S3_ACCESS_KEY_ID', 'S3_SECRET_ACCESS_KEY_ID'],
+  required: ['PORT', 'NODE_ENV', 'GATEWAY_URL', 'S3_BUCKET_NAME', 'AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
   properties: {
     PORT: { type: 'string', default: 3000 },
     NODE_ENV: { type: 'string', default: 'dev' },
     GATEWAY_URL: { type: 'string' },
     S3_BUCKET_NAME: { type: 'string' },
-    S3_BUCKET_REGION: { type: 'string' },
-    S3_ACCESS_KEY_ID: { type: 'string' },
-    S3_SECRET_ACCESS_KEY_ID: { type: 'string' }
+    AWS_REGION: { type: 'string' },
+    AWS_ACCESS_KEY_ID: { type: 'string' },
+    AWS_SECRET_ACCESS_KEY: { type: 'string' }
   }
 }
 

--- a/consumer.js
+++ b/consumer.js
@@ -1,0 +1,34 @@
+import { Consumer } from 'sqs-consumer'
+import { fetchCar, connectTo, disconnect } from './plugins/car.js'
+import { createS3Client, sendToS3 } from './plugins/s3.js'
+
+const { GATEWAY_URL, NODE_ENV, SQS_QUEUE_URL } = process.env
+
+const client = createS3Client(process.env)
+
+const app = Consumer.create({
+  queueUrl: SQS_QUEUE_URL,
+  handleMessage: async (message) => {
+    const { requestid, cid, origins, bucket, key } = JSON.parse(message.body)
+    console.log(`Fetching req: ${requestid} cid: ${cid}`)
+
+    // TODO: check if the work still needs to be done. by asking EP.
+    try {
+      await connectTo(origins, GATEWAY_URL)
+      const body = fetchCar(cid, GATEWAY_URL)
+      await sendToS3({ client, bucket, NODE_ENV }, { body, key })
+    } finally {
+      await disconnect(origins, GATEWAY_URL)
+    }
+  }
+})
+
+app.on('error', (err) => {
+  console.error(err.message)
+})
+
+app.on('processing_error', (err) => {
+  console.error(err.message)
+})
+
+app.start()

--- a/ipfs-pinning-service.yaml
+++ b/ipfs-pinning-service.yaml
@@ -1,0 +1,787 @@
+openapi: 3.0.3
+info:
+  version: "1.0.0"
+  title: 'IPFS Pinning Service API'
+  x-logo:
+    url: "https://bafybeidehxarrk54mkgyl5yxbgjzqilp6tkaz2or36jhq24n3rdtuven54.ipfs.dweb.link/?filename=ipfs-pinning-service.svg"
+  description: "
+  
+  
+## About this spec
+
+The IPFS Pinning Service API is intended to be an implementation-agnostic API&#x3a;
+
+- For use and implementation by pinning service providers
+
+- For use in client mode by IPFS nodes and GUI-based applications
+
+
+### Document scope and intended audience
+
+The intended audience of this document is **IPFS developers** building pinning service clients or servers compatible with this OpenAPI spec.
+Your input and feedback are welcome and valuable as we develop this API spec. Please join the design discussion at [github.com/ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec).
+
+
+**IPFS users** should see the tutorial at [docs.ipfs.io/how-to/work-with-pinning-services](https://docs.ipfs.io/how-to/work-with-pinning-services/) instead.
+
+
+### Related resources
+
+The latest version of this spec and additional resources can be found at:
+
+- Specification: https://github.com/ipfs/pinning-services-api-spec/raw/main/ipfs-pinning-service.yaml
+
+- Docs: https://ipfs.github.io/pinning-services-api-spec/
+
+- Clients and services: https://github.com/ipfs/pinning-services-api-spec#adoption
+
+
+# Schemas
+
+This section describes the most important object types and conventions.
+
+
+A full list of fields and schemas can be found in the `schemas` section of the [YAML file](https://github.com/ipfs/pinning-services-api-spec/blob/master/ipfs-pinning-service.yaml).
+
+
+## Identifiers
+
+### cid
+
+[Content Identifier (CID)](https://docs.ipfs.io/concepts/content-addressing/) points at the root of a DAG that is pinned recursively.
+
+### requestid
+
+Unique identifier of a pin request.
+
+
+When a pin is created, the service responds with unique `requestid` that can be later used for pin removal. When the same `cid` is pinned again, a different `requestid` is returned to differentiate between those pin requests.
+
+
+Service implementation should use UUID, `hash(accessToken,Pin,PinStatus.created)`, or any other opaque identifier that provides equally strong protection against race conditions.
+
+
+## Objects
+
+### Pin object
+
+
+![pin object](https://bafybeideck2fchyxna4wqwc2mo67yriokehw3yujboc5redjdaajrk2fjq.ipfs.dweb.link/pin.png)
+
+
+The `Pin` object is a representation of a pin request.
+
+
+It includes the `cid` of data to be pinned, as well as optional metadata in `name`, `origins`, and `meta`.
+Addresses provided in `origins` list are relevant only during the initial pinning, and don't need to be persisted by the pinning service.
+
+
+### Pin status response
+
+
+![pin status response object](https://bafybeideck2fchyxna4wqwc2mo67yriokehw3yujboc5redjdaajrk2fjq.ipfs.dweb.link/pinstatus.png)
+
+
+The `PinStatus` object is a representation of the current state of a pinning operation.
+
+It includes values from the original `Pin` object, along with the current `status` and globally unique `requestid` of the entire pinning request, which can be used for future status checks and management.
+Addresses in the `delegates` array are peers designated by pinning service that will receive the pin data over bitswap (more details in the [Provider hints](#section/Provider-hints) section). Any additional vendor-specific information is returned in optional `info`.
+
+
+# The pin lifecycle
+
+
+![pinning service objects and lifecycle](https://bafybeideck2fchyxna4wqwc2mo67yriokehw3yujboc5redjdaajrk2fjq.ipfs.dweb.link/lifecycle.png)
+
+
+## Creating a new pin object
+
+The user sends a `Pin` object to `POST /pins` and receives a `PinStatus` response:
+
+- `requestid` in `PinStatus` is the identifier of the pin operation, which can can be used for checking status, and removing the pin in the future
+
+- `status` in `PinStatus` indicates the current state of a pin
+
+
+## Checking status of in-progress pinning
+
+`status` (in `PinStatus`) may indicate a pending state (`queued` or `pinning`). This means the data behind `Pin.cid` was not found on the pinning service and is being fetched from the IPFS network at large, which may take time.
+
+
+In this case, the user can periodically check pinning progress via `GET /pins/{requestid}` until pinning is successful, or the user decides to remove the pending pin.
+
+
+## Replacing an existing pin object
+
+The user can replace an existing pin object via `POST /pins/{requestid}`. This is a shortcut for removing a pin object identified by `requestid` and creating a new one in a single API call that protects against undesired garbage collection of blocks common to both pins. Useful when updating a pin representing a huge dataset where most of blocks did not change. The new pin object `requestid` is returned in the `PinStatus` response. The old pin object is deleted automatically.
+
+
+## Removing a pin object
+
+A pin object can be removed via `DELETE /pins/{requestid}`.
+
+
+
+# Provider hints
+
+Provider hints take the form of two [multiaddr](https://docs.ipfs.io/concepts/glossary/#multiaddr) lists: `Pin.origins` and `PinStatus.delegates`
+
+
+## Pin.origins
+
+A list of known sources (providers) of the data. Sent by a client in a pin request.
+Pinning service will try to connect to them to speed up data transfer.
+
+
+## PinStatus.delegates
+
+A list of temporary destination (retrievers) for the data. Returned by pinning service in a response for a pin request.
+These peers are provided by a pinning service for the purpose of fetching data about to be pinned.
+
+
+## Optimizing for speed and connectivity
+
+Both ends should attempt to preconnect to each other:
+
+- Delegates should always preconnect to origins
+
+- Clients who initiate pin request and also have the pinned data in their own local datastore should preconnect to delegates
+
+
+**NOTE:** Connections to multiaddrs in `origins` and `delegates` arrays should
+be attempted in best-effort fashion, and dial failure should not fail the
+pinning operation. When unable to act on explicit provider hints, DHT and
+other discovery methods should be used as a fallback by a pinning service.
+
+
+## Rationale
+
+A pinning service will use the DHT and other discovery methods to locate pinned
+content; however, it may not be able to retrieve data if the only provider
+has no publicly diallable address (e.g. a desktop peer behind a restrictive NAT/firewall).
+
+
+Leveraging provider hints mitigates potential connectivity issues and speeds up the content routing phase.
+If a client has the data in their own datastore or already knows of other providers, the transfer will start immediately.
+
+
+The most common scenario is a client putting its own IPFS node's multiaddrs in
+`Pin.origins`,  and then attempt to connect to every multiaddr returned by a
+pinning service in `PinStatus.delegates` to initiate transfer.  At the same
+time, a pinning service will try to connect to multiaddrs provided by the client
+in `Pin.origins`.
+
+
+This ensures data transfer starts immediately (without waiting for provider
+discovery over DHT), and mutual direct dial between a client and a service
+works around peer routing issues in restrictive network topologies, such as
+NATs, firewalls, etc.
+
+
+**NOTE:** All multiaddrs MUST end with `/p2p/{peerID}` and SHOULD be fully
+resolved and confirmed to be dialable from the public internet. Avoid sending
+addresses from local networks.
+
+
+# Custom metadata
+
+Pinning services are encouraged to add support for additional features by leveraging the optional `Pin.meta` and `PinStatus.info` fields.
+While these attributes can be application- or vendor-specific, we encourage the community at large to leverage these attributes as a sandbox to come up with conventions that could become part of future revisions of this API.
+
+## Pin metadata
+
+String keys and values passed in `Pin.meta` are persisted with the pin object.
+This is an opt-in feature: It is OK for a client to omit or ignore these optional attributes, and doing so should not impact the basic pinning functionality.
+
+
+Potential uses:
+
+- `Pin.meta[app_id]`: Attaching a unique identifier to pins created by an app enables meta-filtering pins per app
+
+- `Pin.meta[vendor_policy]`: Vendor-specific policy (for example: which region to use, how many copies to keep)
+
+
+### Filtering based on metadata
+
+The contents of `Pin.meta` can be used as an advanced search filter for situations where searching by `name` and `cid` is not enough.
+
+
+Metadata key matching rule is `AND`:
+
+- lookup returns pins that have `meta` with all key-value pairs matching the passed values
+
+- pin metadata may have more keys, but only ones passed in the query are used for filtering
+
+
+The wire format for the `meta` when used as a query parameter is a [URL-escaped](https://en.wikipedia.org/wiki/Percent-encoding) stringified JSON object.
+A lookup example for pins that have a `meta` key-value pair `{\"app_id\":\"UUID\"}` is:
+
+- `GET /pins?meta=%7B%22app_id%22%3A%22UUID%22%7D`
+
+
+
+## Pin status info
+
+Additional `PinStatus.info` can be returned by pinning service.
+
+
+Potential uses:
+
+- `PinStatus.info[status_details]`: more info about the current status (queue
+  position, percentage of transferred data, summary of where data is stored, etc); when
+  `PinStatus.status=failed`, it could provide a reason why a pin operation
+  failed (e.g. lack of funds, DAG too big, etc.)
+
+- `PinStatus.info[dag_size]`: the size of pinned data, along with DAG overhead
+
+- `PinStatus.info[raw_size]`: the size of data without DAG overhead (eg. unixfs)
+
+- `PinStatus.info[pinned_until]`: if vendor supports time-bound pins, this could indicate when the pin will expire
+
+
+# Pagination and filtering
+
+Pin objects can be listed by executing `GET /pins` with optional parameters:
+
+
+- When no filters are provided, the endpoint will return a small batch of the 10 most
+  recently created items, from the latest to the oldest.
+
+- The number of returned items can be adjusted with the `limit` parameter
+  (implicit default is 10).
+
+- If the value in `PinResults.count` is bigger than the length of
+  `PinResults.results`, the client can infer there are more results that can be queried.
+
+- To read more items, pass the `before` filter with the timestamp from
+  `PinStatus.created` found in the oldest item in the current batch of results.
+  Repeat to read all results.
+
+- Returned results can be fine-tuned by applying optional `after`, `cid`, `name`,
+  `status`, or `meta` filters.
+
+
+> **Note**: pagination by the `created` timestamp requires each value to be
+  globally unique. Any future considerations to add support for bulk creation
+  must account for this.
+
+
+"
+
+servers:
+  - url: https://pinning-service.example.com
+
+paths:
+  /pins:
+    get:
+      summary: List pin objects
+      description: List all the pin objects, matching optional filters; when no filter is provided, only successful pins are returned
+      tags:
+        - pins
+      parameters:
+        - $ref: '#/components/parameters/cid'
+        - $ref: '#/components/parameters/name'
+        - $ref: '#/components/parameters/match'
+        - $ref: '#/components/parameters/status'
+        - $ref: '#/components/parameters/before'
+        - $ref: '#/components/parameters/after'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/meta'
+      responses:
+        '200':
+          description: Successful response (PinResults object)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PinResults'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      summary: Add pin object
+      description: Add a new pin object for the current access token
+      tags:
+        - pins
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pin'
+      responses:
+        '202':
+          description: Successful response (PinStatus object)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PinStatus'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
+
+  /pins/{requestid}:
+    parameters:
+      - name: requestid
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get pin object
+      description: Get a pin object and its status
+      tags:
+        - pins
+      responses:
+        '200':
+          description: Successful response (PinStatus object)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PinStatus'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      summary: Replace pin object
+      description: Replace an existing pin object (shortcut for executing remove and add operations in one step to avoid unnecessary garbage collection of blocks present in both recursive pins)
+      tags:
+        - pins
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pin'
+      responses:
+        '202':
+          description: Successful response (PinStatus object)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PinStatus'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      summary: Remove pin object
+      description: Remove a pin object
+      tags:
+        - pins
+      responses:
+        '202':
+          description: Successful response (no body, pin removed)
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/InsufficientFunds'
+        '4XX':
+          $ref: '#/components/responses/CustomServiceError'
+        '5XX':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  schemas:
+
+    PinResults:
+      description: Response used for listing pin objects matching request
+      type: object
+      required:
+        - count
+        - results
+      properties:
+        count:
+          description: The total number of pin objects that exist for passed query filters
+          type: integer
+          format: int32
+          minimum: 0
+          example: 1
+        results:
+          description: An array of PinStatus results
+          type: array
+          items:
+            $ref: '#/components/schemas/PinStatus'
+          uniqueItems: true
+          minItems: 0
+          maxItems: 1000
+
+    PinStatus:
+      description: Pin object with status
+      type: object
+      required:
+        - requestid
+        - status
+        - created
+        - pin
+        - delegates
+      properties:
+        requestid:
+          description: Globally unique identifier of the pin request; can be used to check the status of ongoing pinning, or pin removal
+          type: string
+          example: "UniqueIdOfPinRequest"
+        status:
+          $ref: '#/components/schemas/Status'
+        created:
+          description: Immutable timestamp indicating when a pin request entered a pinning service; can be used for filtering results and pagination
+          type: string
+          format: date-time  # RFC 3339, section 5.6
+          example: "2020-07-27T17:32:28Z"
+        pin:
+          $ref: '#/components/schemas/Pin'
+        delegates:
+          $ref: '#/components/schemas/Delegates'
+        info:
+          $ref: '#/components/schemas/StatusInfo'
+
+    Pin:
+      description: Pin object
+      type: object
+      required:
+        - cid
+      properties:
+        cid:
+          description: Content Identifier (CID) to be pinned recursively
+          type: string
+          example: "QmCIDToBePinned"
+        name:
+          description: Optional name for pinned data; can be used for lookups later
+          type: string
+          maxLength: 255
+          example: "PreciousData.pdf"
+        origins:
+          $ref: '#/components/schemas/Origins'
+        meta:
+          $ref: '#/components/schemas/PinMeta'
+
+    Status:
+      description: Status a pin object can have at a pinning service
+      type: string
+      enum:
+        - queued     # pinning operation is waiting in the queue; additional info can be returned in info[status_details]      
+        - pinning    # pinning in progress; additional info can be returned in info[status_details]
+        - pinned     # pinned successfully
+        - failed     # pinning service was unable to finish pinning operation; additional info can be found in info[status_details]
+
+    Delegates:
+      description: List of multiaddrs designated by pinning service that will receive the pin data; see Provider Hints in the docs
+      type: array
+      items:
+        type: string
+      uniqueItems: true
+      minItems: 1
+      maxItems: 20
+      example: ['/ip4/203.0.113.1/tcp/4001/p2p/QmServicePeerId']
+
+    Origins:
+      description: Optional list of multiaddrs known to provide the data; see Provider Hints in the docs
+      type: array
+      items:
+        type: string
+      uniqueItems: true
+      minItems: 0
+      maxItems: 20
+      example: ['/ip4/203.0.113.142/tcp/4001/p2p/QmSourcePeerId', '/ip4/203.0.113.114/udp/4001/quic/p2p/QmSourcePeerId']
+
+    PinMeta:
+      description: Optional metadata for pin object
+      type: object
+      additionalProperties:
+        type: string
+        minProperties: 0
+        maxProperties: 1000
+      example:
+        app_id: "99986338-1113-4706-8302-4420da6158aa" # Pin.meta[app_id], useful for filtering pins per app
+
+    StatusInfo:
+      description: Optional info for PinStatus response
+      type: object
+      additionalProperties:
+        type: string
+        minProperties: 0
+        maxProperties: 1000
+      example:
+        status_details: "Queue position: 7 of 9" # PinStatus.info[status_details], when status=queued
+
+    TextMatchingStrategy:
+      description: Alternative text matching strategy
+      type: string
+      default: exact
+      enum:
+        - exact    # full match, case-sensitive (the implicit default)
+        - iexact   # full match, case-insensitive
+        - partial  # partial match, case-sensitive
+        - ipartial # partial match, case-insensitive
+
+    Failure:
+      description: Response for a failed request
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          required:
+            - reason
+          properties:
+            reason:
+              type: string
+              description: Mandatory string identifying the type of error
+              example: "ERROR_CODE_FOR_MACHINES"
+            details:
+              type: string
+              description: Optional, longer description of the error; may include UUID of transaction for support, links to documentation etc
+              example: "Optional explanation for humans with more details"
+
+  parameters:
+
+    before:
+      description: Return results created (queued) before provided timestamp
+      name: before
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date-time  # RFC 3339, section 5.6
+      example: "2020-07-27T17:32:28Z"
+
+    after:
+      description: Return results created (queued) after provided timestamp
+      name: after
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date-time  # RFC 3339, section 5.6
+      example: "2020-07-27T17:32:28Z"
+
+    limit:
+      description: Max records to return
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 1000
+        default: 10
+
+    cid:
+      description: Return pin objects responsible for pinning the specified CID(s); be aware that using longer hash functions introduces further constraints on the number of CIDs that will fit under the limit of 2000 characters per URL  in browser contexts
+      name: cid
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+        uniqueItems: true
+        minItems: 1
+        maxItems: 10
+      style: form # ?cid=Qm1,Qm2,bafy3
+      explode: false
+      example: ["Qm1","Qm2","bafy3"]
+
+    name:
+      description: Return pin objects with specified name (by default a case-sensitive, exact match)
+      name: name
+      in: query
+      required: false
+      schema:
+        type: string
+        maxLength: 255
+      example: "PreciousData.pdf"
+
+    match:
+      description: Customize the text matching strategy applied when the name filter is present; exact (the default) is a case-sensitive exact match, partial matches anywhere in the name, iexact and ipartial are case-insensitive versions of the exact and partial strategies
+      name: match
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/TextMatchingStrategy'
+      example: exact
+
+    status:
+      description: Return pin objects for pins with the specified status
+      name: status
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/Status'
+        uniqueItems: true
+        minItems: 1
+      style: form # ?status=queued,pinning
+      explode: false
+      example: ["queued","pinning"]
+
+    meta:
+      description: Return pin objects that match specified metadata keys passed as a string representation of a JSON object; when implementing a client library, make sure the parameter is URL-encoded to ensure safe transport
+      name: meta
+      in: query
+      required: false
+      content:
+        application/json: # ?meta={"foo":"bar"}
+          schema:
+            $ref: '#/components/schemas/PinMeta'
+
+  responses:
+
+    BadRequest:
+      description: Error response (Bad request)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Failure'
+          examples:
+            BadRequestExample:
+              $ref: '#/components/examples/BadRequestExample'
+
+    Unauthorized:
+      description: Error response (Unauthorized; access token is missing or invalid)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Failure'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/UnauthorizedExample'
+
+    NotFound:
+      description: Error response (The specified resource was not found)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Failure'
+          examples:
+            NotFoundExample:
+              $ref: '#/components/examples/NotFoundExample'
+
+    InsufficientFunds:
+      description: Error response (Insufficient funds)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Failure'
+          examples:
+            InsufficientFundsExample:
+              $ref: '#/components/examples/InsufficientFundsExample'
+
+    CustomServiceError:
+      description: Error response (Custom service error)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Failure'
+          examples:
+            CustomServiceErrorExample:
+              $ref: '#/components/examples/CustomServiceErrorExample'
+
+    InternalServerError:
+      description: Error response (Unexpected internal server error)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Failure'
+          examples:
+            InternalServerErrorExample:
+              $ref: '#/components/examples/InternalServerErrorExample'
+
+  examples:
+
+    BadRequestExample:
+      value:
+        error:
+          reason: "BAD_REQUEST"
+          details: "Explanation for humans with more details"
+      summary: A sample response to a bad request; reason will differ
+
+    UnauthorizedExample:
+      value:
+        error:
+          reason: "UNAUTHORIZED"
+          details: "Access token is missing or invalid"
+      summary: Response to an unauthorized request
+
+    NotFoundExample:
+      value:
+        error:
+          reason: "NOT_FOUND"
+          details: "The specified resource was not found"
+      summary: Response to a request for a resource that does not exist
+
+    InsufficientFundsExample:
+      value:
+        error:
+          reason: "INSUFFICIENT_FUNDS"
+          details: "Unable to process request due to the lack of funds"
+      summary: Response when access token run out of funds
+
+    CustomServiceErrorExample:
+      value:
+        error:
+          reason: "CUSTOM_ERROR_CODE_FOR_MACHINES"
+          details: "Optional explanation for humans with more details"
+      summary: Response when a custom error occured
+
+    InternalServerErrorExample:
+      value:
+        error:
+          reason: "INTERNAL_SERVER_ERROR"
+          details: "Explanation for humans with more details"
+      summary: Response when unexpected error occured
+
+  securitySchemes:
+    accessToken:
+      description: "
+An opaque token is required to be sent with each request in the HTTP header:
+
+- `Authorization: Bearer <access-token>`
+
+
+The `access-token` should be generated per device, and the user should have the ability to revoke each token separately.
+"
+      type: http
+      scheme: bearer
+security:
+  - accessToken: []

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   "scripts": {
     "start": "fastify start app.js -l info --pretty-logs --watch --verbose-watch",
     "start:prod": "NODE_ENV=production fastify start app.js -l info",
+    "start:consumer": "node consumer.js",
     "test": "standard",
-    "lint": "standard --fix"
+    "lint": "standard --fix",
+    "build-openapi-validator": "npx ajv-openapi-compile --definition=./ipfs-pinning-service.yaml --schema=./ipfs-pinning-service.js"
   },
   "author": "olizilla",
   "license": "MIT",

--- a/plugins/car.js
+++ b/plugins/car.js
@@ -1,0 +1,47 @@
+import { CID } from 'multiformats/cid'
+import { Multiaddr } from 'multiaddr'
+import fetch from 'node-fetch'
+
+export async function fetchCar (cid, gateway) {
+  if (!isCID(cid)) {
+    throw new Error({ message: `Invalid CID: ${cid}` })
+  }
+  const url = new URL(`/api/v0/dag/export?arg=${cid}`, gateway)
+  const res = await fetch(url, { method: 'POST' })
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText} ${url}`)
+  }
+  return res.body
+}
+
+export async function connectTo (origins, gateway) {
+  // best effort
+  for (const addr of origins.filter(isMultiaddr)) {
+    // TODO: what about  /api/v0/swarm/peering/add ? is better? Should we disconnect also?
+    const url = new URL(`/api/v0/swarm/connect?arg=${addr}`, gateway)
+    fetch(url, { method: 'POST' })
+  }
+}
+
+export async function disconnect (origins, gateway) {
+  // best effort
+  for (const addr of origins.filter(isMultiaddr)) {
+    // TODO: what about  /api/v0/swarm/peering/add ? is better? Should we disconnect also?
+    const url = new URL(`/api/v0/swarm/disconnect?arg=${addr}`, gateway)
+    fetch(url, { method: 'POST' })
+  }
+}
+
+export function isMultiaddr (input) {
+  if (!input) return false
+  try {
+    new Multiaddr(input) // eslint-disable-line no-new
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+export function isCID (str) {
+  return Boolean(CID.parse(str))
+}

--- a/routes/pins.js
+++ b/routes/pins.js
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch'
+import { fetchCar } from '../plugins/car'
 
 export default async function routes (fastify) {
   fastify.get('/', async () => {
@@ -6,17 +6,10 @@ export default async function routes (fastify) {
   })
 
   fastify.post('/pins/:cid', async function ({ params }) {
-    const body = await fetchCar(params.cid, this.env.GATEWAY_URL)
-    await fastify.sendToS3({ body, cid: params.cid /* userId, appName */ })
+    const cid = params.cid
+    const body = await fetchCar(cid, this.env.GATEWAY_URL)
+    const key = fastify.toBucketKey({ cid, userId: 'test', appName: 'test-app' })
+    await fastify.sendToS3({ body, key })
     return { cid: params.cid }
   })
-}
-
-export async function fetchCar (cid, gateway) {
-  const url = new URL(`/api/v0/dag/export?arg=${cid}`, gateway)
-  const res = await fetch(url, { method: 'POST' })
-  if (!res.ok) {
-    throw new Error(`${res.status} ${res.statusText} ${url}`)
-  }
-  return res.body
 }


### PR DESCRIPTION
Adds consumer.js to pull work from an sqs queue. The fastify http api is left in for now, but if things work out it can all go and we can just use the queue consumer as the main entry point

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>