### PR TITLE
fix: skip package diff if not PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   deps:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
codepunkt/npm-lockfile-changes@v1.0.0 doesn't work if not triggered by PR event.

fixes: https://github.com/olizilla/pickup/runs/7406866201?check_suite_focus=true

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>